### PR TITLE
Add new templates

### DIFF
--- a/.DEREK.yml
+++ b/.DEREK.yml
@@ -1,0 +1,1 @@
+redirect: https://raw.githubusercontent.com/openfaas/faas/master/.DEREK.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target
+Cargo.lock
+build

--- a/README.md
+++ b/README.md
@@ -1,2 +1,102 @@
 # rust-http-template
-An OpenFaaS of-watchdog template written in Rust
+
+An OpenFaaS of-watchdog template written in Rust.
+
+This repository contains two Rust templates for OpenFaaS, one of which gives additional control over the HTTP request and response. They will both handle higher throughput than the classic watchdog due to the process being kept warm.
+
+```sh
+$ faas template pull https://github.com/openfaas-incubator/rust-http-template
+$ faas new --list
+Languages available as templates:
+- rust
+- rust-http
+```
+
+## rust-http-template/rust
+
+This template takes body serialized to `Vec` of bytes as an input.
+
+```Rust
+type Error = Box<dyn std::error::Error>;
+
+pub fn handle(body: Vec<u8>) -> Result<Vec<u8>, Error> {
+    Ok(body)
+}
+
+// Returns:
+// Hello, World!
+```
+
+You can return custom errors using `Result`.
+
+```Rust
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+struct MyError {
+    details: String
+}
+
+impl MyError {
+    fn new(msg: &str) -> MyError {
+        MyError{details: msg.to_string()}
+    }
+}
+
+impl fmt::Display for MyError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f,"{}",self.details)
+    }
+}
+
+impl Error for MyError {
+    fn description(&self) -> &str {
+        &self.details
+    }
+}
+
+type BoxError = Box<dyn Error>;
+
+pub fn handle(_body: Vec<u8>) -> Result<Vec<u8>, BoxError> {
+    let error = MyError::new("my error");
+    Err(Box::new(error))
+}
+
+
+// Returns:
+// {"status": "500 Internal Server Error", "description":"my error"}
+```
+
+## rust-http-template/rust-http
+
+This template gives you more control over handling function input and output.
+
+```Rust
+use hyper::{Body, Request, Response};
+
+const PHRASE: &str = "Hello, World!";
+
+pub fn handle(_req: Request<Body>) -> Response<Body> {
+    Response::new(Body::from(PHRASE))
+}
+
+// Returns:
+// Hello, World!
+```
+
+You can return custom errors using `hyper::Response`.
+
+```Rust
+use hyper::{Body, Request, Response, StatusCode};
+
+pub fn handle(_req: Request<Body>) -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::INTERNAL_SERVER_ERROR)
+        .body(Body::from("my error"))
+        .unwrap()
+}
+
+// Returns:
+// my error
+```

--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ This template takes body serialized to `Vec` of bytes as an input.
 ```Rust
 type Error = Box<dyn std::error::Error>;
 
-pub fn handle(body: Vec<u8>) -> Result<Vec<u8>, Error> {
-    Ok(body)
+const PHRASE: &str = "Hello, World!";
+
+pub fn handle(_body: Vec<u8>) -> Result<Vec<u8>, Error> {
+    Ok(PHRASE.as_bytes().to_vec())
 }
 
 // Returns:

--- a/template/rust-http/.dockerignore
+++ b/template/rust-http/.dockerignore
@@ -1,0 +1,4 @@
+target
+Cargo.lock
+build
+tests

--- a/template/rust-http/Dockerfile
+++ b/template/rust-http/Dockerfile
@@ -1,0 +1,65 @@
+FROM openfaas/of-watchdog:0.7.2 as watchdog
+
+# We are going to build static Rust binary
+# Reference: https://github.com/emk/rust-musl-builder
+FROM ekidd/rust-musl-builder:latest AS builder
+
+WORKDIR /home/rust
+
+# Cargo requires $USER to be set
+ENV USER=rust
+
+# Cache dependencies
+
+# Create empty projects
+RUN cargo new --lib function && \
+    cargo new --bin main
+
+# Copy Cargo files
+COPY function/Cargo.toml ./function/Cargo.toml
+COPY --chown=rust:rust function/Cargo.lock ./function/Cargo.lock
+COPY main/Cargo.toml ./main/Cargo.toml
+COPY --chown=rust:rust main/Cargo.lock ./main/Cargo.lock
+
+# Download and build deps
+RUN cd function && cargo build
+RUN cd main && cargo build
+
+# Build the binary
+
+# Copy all the sources
+COPY --chown=rust:rust function ./function
+COPY --chown=rust:rust main ./main
+
+# And build in release mode
+RUN cd main && cargo build --release --target=x86_64-unknown-linux-musl
+
+# Prepare runtime image
+FROM alpine:latest
+
+WORKDIR /home/app
+
+# Install packages and add non-root user
+RUN apk --no-cache add curl ca-certificates \
+    && addgroup -S app && adduser -S -g app app
+
+# Copy of-watchdog binary
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
+
+# Copy the binary from builder
+COPY --from=builder --chown=app:app \
+    /home/rust/main/target/x86_64-unknown-linux-musl/release/main \
+    /home/app/main
+
+# Switch to non-root user
+USER app
+
+# Set up watchdog for HTTP mode
+ENV fprocess="./main"
+ENV mode="http"
+ENV upstream_url="http://127.0.0.1:3000"
+
+HEALTHCHECK --interval=3s CMD [ -e /tmp/.lock ] || exit 1
+
+CMD ["fwatchdog"]

--- a/template/rust-http/function/Cargo.toml
+++ b/template/rust-http/function/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "handler"
+version = "0.1.0"
+authors = ["Piotr Roslaniec <p.roslaniec@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+hyper = "0.12"

--- a/template/rust-http/function/src/lib.rs
+++ b/template/rust-http/function/src/lib.rs
@@ -1,0 +1,7 @@
+use hyper::{Body, Request, Response};
+
+const PHRASE: &str = "Hello, World!";
+
+pub fn handle(_req: Request<Body>) -> Response<Body> {
+    Response::new(Body::from(PHRASE))
+}

--- a/template/rust-http/main/Cargo.toml
+++ b/template/rust-http/main/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "main"
+version = "0.1.0"
+authors = ["Piotr Roslaniec <p.roslaniec@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+handler = { path = "../function" }
+futures = "0.1"
+hyper = "0.12"

--- a/template/rust-http/main/src/main.rs
+++ b/template/rust-http/main/src/main.rs
@@ -1,0 +1,23 @@
+use futures::future;
+use hyper::rt::Future;
+use hyper::service::service_fn;
+use hyper::{Body, Request, Response, Server};
+
+use handler;
+
+type BoxFuture = Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send>;
+
+fn handler_service(req: Request<Body>) -> BoxFuture {
+    let resp = handler::handle(req);
+    Box::new(future::ok(resp))
+}
+
+fn main() {
+    let addr = ([0, 0, 0, 0], 3000).into();
+
+    let server = Server::bind(&addr)
+        .serve(|| service_fn(handler_service))
+        .map_err(|e| eprintln!("server error: {}", e));
+
+    hyper::rt::run(server);
+}

--- a/template/rust-http/template.yml
+++ b/template/rust-http/template.yml
@@ -1,0 +1,2 @@
+language: rust
+fprocess: main

--- a/template/rust/.dockerignore
+++ b/template/rust/.dockerignore
@@ -1,0 +1,4 @@
+target
+Cargo.lock
+build
+tests

--- a/template/rust/Dockerfile
+++ b/template/rust/Dockerfile
@@ -1,0 +1,65 @@
+FROM openfaas/of-watchdog:0.7.2 as watchdog
+
+# We are going to build static Rust binary
+# Reference: https://github.com/emk/rust-musl-builder
+FROM ekidd/rust-musl-builder:latest AS builder
+
+WORKDIR /home/rust
+
+# Cargo requires $USER to be set
+ENV USER=rust
+
+# Cache dependencies
+
+# Create empty projects
+RUN cargo new --lib function && \
+    cargo new --bin main
+
+# Copy Cargo files
+COPY function/Cargo.toml ./function/Cargo.toml
+COPY --chown=rust:rust function/Cargo.lock ./function/Cargo.lock
+COPY main/Cargo.toml ./main/Cargo.toml
+COPY --chown=rust:rust main/Cargo.lock ./main/Cargo.lock
+
+# Download and build deps
+RUN cd function && cargo build
+RUN cd main && cargo build
+
+# Build the binary
+
+# Copy all the sources
+COPY --chown=rust:rust function ./function
+COPY --chown=rust:rust main ./main
+
+# And build in release mode
+RUN cd main && cargo build --release --target=x86_64-unknown-linux-musl
+
+# Prepare runtime image
+FROM alpine:latest
+
+WORKDIR /home/app
+
+# Install packages and add non-root user
+RUN apk --no-cache add curl ca-certificates \
+    && addgroup -S app && adduser -S -g app app
+
+# Copy of-watchdog binary
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
+
+# Copy the binary from builder
+COPY --from=builder --chown=app:app \
+    /home/rust/main/target/x86_64-unknown-linux-musl/release/main \
+    /home/app/main
+
+# Switch to non-root user
+USER app
+
+# Set up watchdog for HTTP mode
+ENV fprocess="./main"
+ENV mode="http"
+ENV upstream_url="http://127.0.0.1:3000"
+
+HEALTHCHECK --interval=3s CMD [ -e /tmp/.lock ] || exit 1
+
+CMD ["fwatchdog"]

--- a/template/rust/function/Cargo.toml
+++ b/template/rust/function/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "handler"
+version = "0.1.0"
+authors = ["Piotr Roslaniec <p.roslaniec@gmail.com>"]
+edition = "2018"
+
+[dependencies]

--- a/template/rust/function/src/lib.rs
+++ b/template/rust/function/src/lib.rs
@@ -1,0 +1,7 @@
+type Error = Box<dyn std::error::Error>;
+
+const PHRASE: &str = "Hello, World!";
+
+pub fn handle(_body: Vec<u8>) -> Result<Vec<u8>, Error> {
+    Ok(PHRASE.as_bytes().to_vec())
+}

--- a/template/rust/main/Cargo.toml
+++ b/template/rust/main/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "main"
+version = "0.1.0"
+authors = ["Piotr Roslaniec <p.roslaniec@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+handler = { path = "../function" }
+futures = "0.1"
+hyper = "0.12"

--- a/template/rust/main/src/main.rs
+++ b/template/rust/main/src/main.rs
@@ -1,0 +1,42 @@
+use futures::stream::Stream;
+use hyper::rt::Future;
+use hyper::service::service_fn;
+use hyper::{Body, Request, Response, Server, StatusCode};
+
+use handler;
+
+type BoxFuture = Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send>;
+type Error = Box<dyn std::error::Error>;
+
+fn finalize(result: Result<Vec<u8>, Error>) -> Response<Body> {
+    match result {
+        Ok(bytes) => Response::new(Body::from(bytes)),
+        Err(error) => {
+            let body = format!(
+                "{{\"status\": \"{}\", \"description\":\"{}\"}}",
+                StatusCode::INTERNAL_SERVER_ERROR.to_string(),
+                error.description()
+            );
+            let mut resp = Response::new(Body::from(body));
+            *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+            resp
+        }
+    }
+}
+
+fn handler_service(req: Request<Body>) -> BoxFuture {
+    Box::new(req.into_body().concat2().map(move |chunk| {
+        let body = chunk.iter().cloned().collect::<Vec<u8>>();
+        finalize(handler::handle(body))
+    }))
+}
+
+fn main() {
+    let addr = ([0, 0, 0, 0], 3000).into();
+
+    let server = Server::bind(&addr)
+        .serve(|| service_fn(handler_service))
+        .map_err(|e| eprintln!("server error: {}", e));
+
+    hyper::rt::run(server);
+}

--- a/template/rust/template.yml
+++ b/template/rust/template.yml
@@ -1,0 +1,2 @@
+language: rust
+fprocess: main


### PR DESCRIPTION
This PR adds two implementations of Rust templates to be used with of-watchdog. Please see attached `README.md` for details.

Signed-off-by: Piotr Roslaniec <p.roslaniec@gmail.com>