### PR TITLE
[Fix] Removes cargo.lock from the dockerfile template

### DIFF
--- a/template/rust-http/Dockerfile
+++ b/template/rust-http/Dockerfile
@@ -17,9 +17,7 @@ RUN cargo new --lib function && \
 
 # Copy Cargo files
 COPY function/Cargo.toml ./function/Cargo.toml
-COPY --chown=rust:rust function/Cargo.lock ./function/Cargo.lock
 COPY main/Cargo.toml ./main/Cargo.toml
-COPY --chown=rust:rust main/Cargo.lock ./main/Cargo.lock
 
 # Download and build deps
 RUN cd function && cargo build

--- a/template/rust/Dockerfile
+++ b/template/rust/Dockerfile
@@ -17,9 +17,7 @@ RUN cargo new --lib function && \
 
 # Copy Cargo files
 COPY function/Cargo.toml ./function/Cargo.toml
-COPY --chown=rust:rust function/Cargo.lock ./function/Cargo.lock
 COPY main/Cargo.toml ./main/Cargo.toml
-COPY --chown=rust:rust main/Cargo.lock ./main/Cargo.lock
 
 # Download and build deps
 RUN cd function && cargo build


### PR DESCRIPTION
The following PR will fix the template from not working, by not copying the following files `cargo.lock` since the templates won't have them the moment the following command is executed `faas-cli up -f function.yml`. and the locks are only generated when we call `cargo build` or `cargo run`
However, this doesn't fix the issue where the function can't be executed by calling `http://127.0.0.1:31112/function/function`, that I am still unsure of