### PR TITLE
install gcc-musl

### DIFF
--- a/template/rust-http/Dockerfile
+++ b/template/rust-http/Dockerfile
@@ -8,6 +8,9 @@ WORKDIR /home/rust
 COPY function ./function
 COPY main ./main
 
+RUN export DEBIAN_FRONTEND=noninteractive && apt update \
+    && apt install -y musl-tools
+
 RUN cd main && cargo build --target x86_64-unknown-linux-musl --release
 
 FROM alpine:3.11 as runner

--- a/template/rust/Dockerfile
+++ b/template/rust/Dockerfile
@@ -8,6 +8,9 @@ WORKDIR /home/rust
 COPY function ./function
 COPY main ./main
 
+RUN export DEBIAN_FRONTEND=noninteractive && apt update \
+    && apt install -y musl-tools
+
 RUN cd main && cargo build --target x86_64-unknown-linux-musl --release
 
 FROM alpine:3.11 as runner
@@ -23,7 +26,7 @@ COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
 # Set up watchdog for HTTP mode
-ENV fprocess="./main"
+ENV fprocess="./main"   
 ENV mode="http"
 ENV upstream_url="http://127.0.0.1:3000"
 


### PR DESCRIPTION
It is very helpful to have musl-tools installed for rust musl targets.