### PR TITLE
Fix docker images to newer versions + optimise

### DIFF
--- a/template/rust-http/Dockerfile
+++ b/template/rust-http/Dockerfile
@@ -17,7 +17,7 @@ RUN chmod +x /usr/bin/fwatchdog
 
 ARG ADDITIONAL_PKG=""
 # Install packages and add non-root user
-RUN apk --no-cache add curl ca-certificates libgcc gcompat ${ADDITIONAL_PKG} \
+RUN apk --no-cache add curl ca-certificates ${ADDITIONAL_PKG} \
     && addgroup -S app && adduser -S -g app app
 
 # Split instructions so that buildkit can run & cache
@@ -27,8 +27,7 @@ RUN mkdir -p /home/app \
 
 WORKDIR /home/app
 
-COPY --from=build --chown=app:app /home/rust/main/target/release/main .
-RUN chmod +x . && ldd main # test if required links are available
+COPY --from=build --chown=app:app /home/rust/main/target/x86_64-unknown-linux-musl/release/main .
 
 USER app
 

--- a/template/rust-http/Dockerfile
+++ b/template/rust-http/Dockerfile
@@ -27,12 +27,12 @@ RUN mkdir -p /home/app \
 
 WORKDIR /home/app
 
-COPY --from=build --chown=app:app /home/rust/main/target/x86_64-unknown-linux-musl/release/main .
+COPY --from=build --chown=app:app /home/rust/main/target/x86_64-unknown-linux-musl/release/main /usr/bin/main
 
 USER app
 
 # Set up watchdog for HTTP mode
-ENV fprocess="./main"
+ENV fprocess="main"
 ENV mode="http"
 ENV upstream_url="http://127.0.0.1:3000"
 

--- a/template/rust-http/Dockerfile
+++ b/template/rust-http/Dockerfile
@@ -1,32 +1,43 @@
-FROM openfaas/of-watchdog:0.7.2 as watchdog
-
-FROM rust:1.37-alpine as builder
+FROM ghcr.io/openfaas/of-watchdog:0.9.11 as watchdog
+FROM rust:1.56-alpine as build
 
 WORKDIR /home/rust
 
 # Copy all the sources
-COPY function ./function
 COPY main ./main
+COPY function ./function
 
-RUN cd main && cargo build --target x86_64-unknown-linux-musl --release
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cd main && cargo build --target x86_64-unknown-linux-musl --release
 
-FROM alpine:3.11 as runner
+FROM alpine:3.17.2 as ship
 
-# Install packages and add non-root user
-RUN apk --no-cache add curl ca-certificates \
-    && addgroup -S app && adduser -S -g app app
-
-ENV USER=app
-
-# Copy of-watchdog binary
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
+
+ARG ADDITIONAL_PKG=""
+# Install packages and add non-root user
+RUN apk --no-cache add curl ca-certificates libgcc gcompat ${ADDITIONAL_PKG} \
+    && addgroup -S app && adduser -S -g app app
+
+# Split instructions so that buildkit can run & cache
+# the previous command ahead of time.
+RUN mkdir -p /home/app \
+    && chown app /home/app
+
+WORKDIR /home/app
+
+COPY --from=build --chown=app:app /home/rust/main/target/release/main .
+RUN chmod +x . && ldd main # test if required links are available
+
+USER app
 
 # Set up watchdog for HTTP mode
 ENV fprocess="./main"
 ENV mode="http"
 ENV upstream_url="http://127.0.0.1:3000"
 
+EXPOSE 8080
 HEALTHCHECK --interval=3s CMD [ -e /tmp/.lock ] || exit 1
 
 CMD ["fwatchdog"]

--- a/template/rust-http/main/src/main.rs
+++ b/template/rust-http/main/src/main.rs
@@ -3,8 +3,6 @@ use hyper::rt::Future;
 use hyper::service::service_fn;
 use hyper::{Body, Request, Response, Server};
 
-use handler;
-
 type BoxFuture = Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 
 fn handler_service(req: Request<Body>) -> BoxFuture {

--- a/template/rust/Dockerfile
+++ b/template/rust/Dockerfile
@@ -17,7 +17,7 @@ RUN chmod +x /usr/bin/fwatchdog
 
 ARG ADDITIONAL_PKG=""
 # Install packages and add non-root user
-RUN apk --no-cache add curl ca-certificates libgcc gcompat ${ADDITIONAL_PKG} \
+RUN apk --no-cache add curl ca-certificates ${ADDITIONAL_PKG} \
     && addgroup -S app && adduser -S -g app app
 
 # Split instructions so that buildkit can run & cache
@@ -27,8 +27,7 @@ RUN mkdir -p /home/app \
 
 WORKDIR /home/app
 
-COPY --from=build --chown=app:app /home/rust/main/target/release/main .
-RUN chmod +x . && ldd main # test if required links are available
+COPY --from=build --chown=app:app /home/rust/main/target/x86_64-unknown-linux-musl/release/main .
 
 USER app
 

--- a/template/rust/Dockerfile
+++ b/template/rust/Dockerfile
@@ -27,12 +27,12 @@ RUN mkdir -p /home/app \
 
 WORKDIR /home/app
 
-COPY --from=build --chown=app:app /home/rust/main/target/x86_64-unknown-linux-musl/release/main .
+COPY --from=build --chown=app:app /home/rust/main/target/x86_64-unknown-linux-musl/release/main /usr/bin/main
 
 USER app
 
 # Set up watchdog for HTTP mode
-ENV fprocess="./main"
+ENV fprocess="main"
 ENV mode="http"
 ENV upstream_url="http://127.0.0.1:3000"
 

--- a/template/rust/Dockerfile
+++ b/template/rust/Dockerfile
@@ -1,32 +1,43 @@
-FROM openfaas/of-watchdog:0.7.2 as watchdog
-
-FROM rust:1.37-alpine as builder
+FROM ghcr.io/openfaas/of-watchdog:0.9.11 as watchdog
+FROM rust:1.56-alpine as build
 
 WORKDIR /home/rust
 
 # Copy all the sources
-COPY function ./function
 COPY main ./main
+COPY function ./function
 
-RUN cd main && cargo build --target x86_64-unknown-linux-musl --release
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cd main && cargo build --target x86_64-unknown-linux-musl --release
 
-FROM alpine:3.11 as runner
+FROM alpine:3.17.2 as ship
 
-# Install packages and add non-root user
-RUN apk --no-cache add curl ca-certificates \
-    && addgroup -S app && adduser -S -g app app
-
-ENV USER=app
-
-# Copy of-watchdog binary
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
+
+ARG ADDITIONAL_PKG=""
+# Install packages and add non-root user
+RUN apk --no-cache add curl ca-certificates libgcc gcompat ${ADDITIONAL_PKG} \
+    && addgroup -S app && adduser -S -g app app
+
+# Split instructions so that buildkit can run & cache
+# the previous command ahead of time.
+RUN mkdir -p /home/app \
+    && chown app /home/app
+
+WORKDIR /home/app
+
+COPY --from=build --chown=app:app /home/rust/main/target/release/main .
+RUN chmod +x . && ldd main # test if required links are available
+
+USER app
 
 # Set up watchdog for HTTP mode
 ENV fprocess="./main"
 ENV mode="http"
 ENV upstream_url="http://127.0.0.1:3000"
 
+EXPOSE 8080
 HEALTHCHECK --interval=3s CMD [ -e /tmp/.lock ] || exit 1
 
 CMD ["fwatchdog"]

--- a/template/rust/main/src/main.rs
+++ b/template/rust/main/src/main.rs
@@ -3,8 +3,6 @@ use hyper::rt::Future;
 use hyper::service::service_fn;
 use hyper::{Body, Request, Response, Server, StatusCode};
 
-use handler;
-
 type BoxFuture = Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 type Error = Box<dyn std::error::Error>;
 
@@ -15,7 +13,7 @@ fn finalize(result: Result<Vec<u8>, Error>) -> Response<Body> {
             let body = format!(
                 "{{\"status\": \"{}\", \"description\":\"{}\"}}",
                 StatusCode::INTERNAL_SERVER_ERROR.to_string(),
-                error.description()
+                error.to_string()
             );
             let mut resp = Response::new(Body::from(body));
             *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
# Intro

I just started using faasd a short while back and I have been wanting to try and play around with some rust. When I tried installing the template from the store, but it seemed it was a bit out of date (it was still pointing to docker hub).

Since I just started using faas I have been wanting to have some small introduction to actually writing a template and not a function. Partly because I am the sole DevOps person in the company so I am more focused on the deployment and infrastructure and making tools which makes the developers happy. 

I have been looking at the official golang-http template and the node17 as inspiration to update this. It has given me a good opportunity looking closer at these.

This is a summary of what I have done:

- update to newer image versions
- update using buildx for not having to update registry every time
- add ARG for additional packages
- fix some deprecated code in main.rs

# Issue

When I try deploying a new function based on the template I get:

```bash
root@faas1:~# faas-cli logs test-rust
2023-03-28T17:04:54Z 2023/03/28 17:04:54 Version: 0.9.11	SHA: ae2f5089ae66f81a1475c4664cb8f5edb6c096bf
2023-03-28T17:04:54Z 2023/03/28 17:04:54 Forking: main, arguments: []
2023-03-28T17:04:54Z 2023/03/28 17:04:54 Started logging: stderr from function.
2023-03-28T17:04:54Z 2023/03/28 17:04:54 Started logging: stdout from function.
2023-03-28T17:04:54Z 2023/03/28 17:04:54 Watchdog mode: http	fprocess: "main"
2023-03-28T17:04:54Z 2023/03/28 17:04:54 Timeouts: read: 30s write: 30s hard: 30s health: 30s
2023-03-28T17:04:54Z 2023/03/28 17:04:54 Listening on port: 8080
2023-03-28T17:04:54Z 2023/03/28 17:04:54 Writing lock-file to: /tmp/.lock
2023-03-28T17:04:54Z 2023/03/28 17:04:54 Error scanning stderr: read |0: file already closed
2023-03-28T17:04:54Z 2023/03/28 17:04:54 Error scanning stdout: read |0: file already closed
2023-03-28T17:04:54Z 2023/03/28 17:04:54 Forked function has terminated: exec: not started
```

But if I run it locally:

```bash
kfj@troldepus:~/Projects/rust-http-template$ docker run ghcr.io/klausfyhn/test-rust:latest
2023/03/28 17:08:07 Version: 0.9.11	SHA: ae2f5089ae66f81a1475c4664cb8f5edb6c096bf
2023/03/28 17:08:07 Forking: ./main, arguments: []
2023/03/28 17:08:07 Started logging: stderr from function.
2023/03/28 17:08:07 Started logging: stdout from function.
2023/03/28 17:08:07 Watchdog mode: http	fprocess: "./main"
2023/03/28 17:08:07 Timeouts: read: 30s write: 30s hard: 30s health: 30s
2023/03/28 17:08:07 Listening on port: 8080
2023/03/28 17:08:07 Writing lock-file to: /tmp/.lock
2023/03/28 17:08:07 Metrics listening on port: 8081
```

Same if I run it directly with `crt` on `faas1`:

```bash
root@faas1:~# ctr images pull ghcr.io/klausfyhn/test-rust:latest
root@faas1:~# ctr run ghcr.io/klausfyhn/test-rust:latest little-test
2023/03/28 17:13:01 Version: 0.9.11	SHA: ae2f5089ae66f81a1475c4664cb8f5edb6c096bf
2023/03/28 17:13:01 Forking: ./main, arguments: []
2023/03/28 17:13:01 Started logging: stderr from function.
2023/03/28 17:13:01 Started logging: stdout from function.
2023/03/28 17:13:01 Watchdog mode: http	fprocess: "./main"
2023/03/28 17:13:01 Timeouts: read: 30s write: 30s hard: 30s health: 30s
2023/03/28 17:13:01 Listening on port: 8080
2023/03/28 17:13:01 Writing lock-file to: /tmp/.lock
2023/03/28 17:13:01 Metrics listening on port: 8081
```

I have made the image `ghcr.io/klausfyhn/test-rust:latest`  open to the public.

