### PR TITLE
Minor fix to deprecated error and single component imports

### DIFF
--- a/template/rust-http/main/src/main.rs
+++ b/template/rust-http/main/src/main.rs
@@ -3,8 +3,6 @@ use hyper::rt::Future;
 use hyper::service::service_fn;
 use hyper::{Body, Request, Response, Server};
 
-use handler;
-
 type BoxFuture = Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 
 fn handler_service(req: Request<Body>) -> BoxFuture {

--- a/template/rust/main/src/main.rs
+++ b/template/rust/main/src/main.rs
@@ -3,8 +3,6 @@ use hyper::rt::Future;
 use hyper::service::service_fn;
 use hyper::{Body, Request, Response, Server, StatusCode};
 
-use handler;
-
 type BoxFuture = Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 type Error = Box<dyn std::error::Error>;
 

--- a/template/rust/main/src/main.rs
+++ b/template/rust/main/src/main.rs
@@ -13,7 +13,7 @@ fn finalize(result: Result<Vec<u8>, Error>) -> Response<Body> {
             let body = format!(
                 "{{\"status\": \"{}\", \"description\":\"{}\"}}",
                 StatusCode::INTERNAL_SERVER_ERROR.to_string(),
-                error.description()
+                error.to_string()
             );
             let mut resp = Response::new(Body::from(body));
             *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
- Follow linting rule https://rust-lang.github.io/rust-clippy/master/index.html#single_component_path_imports
- Fix deprecated function on error (description)