### PR TITLE
Minor fix of a linting rule and use of deprecated function in error interface

### DIFF
--- a/template/rust-http/main/src/main.rs
+++ b/template/rust-http/main/src/main.rs
@@ -3,8 +3,6 @@ use hyper::rt::Future;
 use hyper::service::service_fn;
 use hyper::{Body, Request, Response, Server};
 
-use handler;
-
 type BoxFuture = Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 
 fn handler_service(req: Request<Body>) -> BoxFuture {

--- a/template/rust/main/src/main.rs
+++ b/template/rust/main/src/main.rs
@@ -3,8 +3,6 @@ use hyper::rt::Future;
 use hyper::service::service_fn;
 use hyper::{Body, Request, Response, Server, StatusCode};
 
-use handler;
-
 type BoxFuture = Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 type Error = Box<dyn std::error::Error>;
 

--- a/template/rust/main/src/main.rs
+++ b/template/rust/main/src/main.rs
@@ -13,7 +13,7 @@ fn finalize(result: Result<Vec<u8>, Error>) -> Response<Body> {
             let body = format!(
                 "{{\"status\": \"{}\", \"description\":\"{}\"}}",
                 StatusCode::INTERNAL_SERVER_ERROR.to_string(),
-                error.description()
+                error.to_string()
             );
             let mut resp = Response::new(Body::from(body));
             *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
These are the rust updates referred to here https://github.com/openfaas-incubator/rust-http-template/pull/9#issuecomment-1502917552

Fixes:

- linting error: https://rust-lang.github.io/rust-clippy/master/index.html#single_component_path_imports
- error description is deprecated: https://doc.rust-lang.org/std/error/trait.Error.html#method.description